### PR TITLE
fix(caret): 修复 QQNT 长组合候选窗锚点振荡

### DIFF
--- a/data/compat.toml
+++ b/data/compat.toml
@@ -7,6 +7,13 @@
 #   comment:              说明（仅文档用途）
 #   caret_use_top:        使用 caret rect 的 top 而非 bottom 定位候选框
 #                         适用于 GetTextExt 返回的 height 不稳定的 WebView 应用
+#   composition_start_pair_guard:
+#                         将 TSF_COMPOSITION（selection 无效、以组合起点降级）紧接
+#                         TSF_SELECTION 且 compStart 不变的两帧识别为同一次采样，禁止
+#                         把正常的“组合起点→当前插入点”跨度当成锚点整体错误。
+#                         只给已实测存在该交替序列的宿主开启；普通宿主保持原有大偏移
+#                         自愈，不能仅凭非零 compStart 全局开启。用户层同名规则若
+#                         未写本字段会继承出厂值；显式 false 才关闭。
 #   first_show_mode:      候选框首显策略，三档互斥；不写=跟随全局
 #                         config.toml 的 [ui.candidate] first_show_mode（出厂 "fast"）。
 #                         "fast"    默认。仍等坐标，但等到「可信」即放行。DLL 在首帧
@@ -81,6 +88,11 @@ process = "Weixin.exe"
 comment = "微信 - Qt WebView 输入框 caret height 不稳定（h=1 或 h=20），使用 rect.top 定位；组合期间上报的 rect 还会停在上一次组合的位置（差 136~419px），需拦截陈旧试探坐标"
 caret_use_top = true
 stale_probe_guard = true
+
+[[apps]]
+process = "QQ.exe"
+comment = "QQNT 聊天框长组合时交替上报组合起点降级帧与当前 selection；compStart 稳定，caret 跨度不是锚点错误"
+composition_start_pair_guard = true
 
 [[apps]]
 process = "SearchHost.exe"

--- a/docs/architecture/caret-position-host-compat-notes.md
+++ b/docs/architecture/caret-position-host-compat-notes.md
@@ -1,7 +1,7 @@
 # 候选窗定位：宿主兼容性与必测矩阵
 
 本文记录候选窗「画在哪」这一族问题的实测结论。2026-09 的一轮迭代里，同一批代码在微信、
-Excel、WPS 表格、EverEdit、记事本上暴露出**七种互不相同的错位形态**，每一种都只在特定宿主
+QQNT、Excel、WPS 表格、EverEdit、记事本上暴露出**八种互不相同的错位形态**，每一种都只在特定宿主
 的特定节奏下出现——**没有哪个宿主能代表其他宿主**。
 
 > 首显档位（`fast`/`wait`/`instant`）本身的设计见
@@ -19,7 +19,7 @@ Excel、WPS 表格、EverEdit、记事本上暴露出**七种互不相同的错�
 | `shown_anchor` | 候选窗**此刻画在屏幕的哪里** | `notify_ui_update` 的首显与坐标校正 | `reset_first_show`（组合结束）；**不**含焦点切换 |
 | `caret_baseline` | 上一次**被认可**的插入点 | `handle_caret_update` 的 settle 吸收与 reshow 两处 | `reset_first_show` |
 
-三条不变量，各自对应一种已实测的缺陷：
+四条不变量，各自对应一种已实测的缺陷：
 
 - **缓存 ≠ 显示位置。** `probe` 和被 `settle` 吸收的坐标都会悄悄改写缓存，而候选窗并不跟着动。
   - 拿缓存当**校正基准** ⇒ 缓存跑到候选窗前面，之后任何比较都得出「没变化」，错位**永远无法
@@ -34,6 +34,11 @@ Excel、WPS 表格、EverEdit、记事本上暴露出**七种互不相同的错�
 - **`shown_anchor` 在焦点切换时刻意不清。** 它答的是「候选窗此刻画在屏幕哪里」，而焦点切换并
   不会把候选窗从屏幕上抹掉——清掉反而让校正判据失去唯一基准，错位再也纠正不回来。它只在候选
   窗真正消失时（`reset_first_show`）作废。
+- **组合跨度 ≠ 起点错误。** 嵌入预编辑中，当前 caret 随组合增长而远离 `composition_start` 是正常
+  现象。大偏移逃生阀若以这段距离判断「起点锁错」，长组合跨过阈值后就会把组合末端误锁成起点。
+  但也不能因此全局信任非零 compStart——其它宿主有陈旧值和坐标系混用历史。QQNT 以 per-app
+  `composition_start_pair_guard` 声明其特征，再由来源顺序、前帧降级点、reported compStart 与当前锁
+  四重一致性识别帧对；未命中时仍走原 caret 大偏移自愈。
 
 ## 二、宿主分类与各自的坑
 
@@ -97,10 +102,25 @@ Excel、WPS 表格、EverEdit、记事本上暴露出**七种互不相同的错�
 字宽大（WindTerm 实测 24px）、行内重排幅度大（同行左移 312px 实测过）。它们是**位置类启发式
 判据的天然反例**——本轮四版「用位置判断这一帧准不准」的启发式，有两版就是被这类宿主推翻的。
 
+### E 类：QQNT——同一按键交替上报起点降级帧与 selection 帧
+
+代表：**QQNT（`QQ.exe`，窗口类 `Chrome_WidgetWin_1`）**。目前只在 QQ 复现，其他宿主未观察到
+相同闪烁。
+
+QQ 的 reported compStart 正常且稳定，但同一按键后会先后出现：
+
+1. `TSF_COMPOSITION`：selection 暂时无效，DLL 用 composition start 降级成 caret；
+2. `TSF_SELECTION`：selection 恢复，caret 回到组合末端，compStart 仍是原起点。
+
+长拼音令组合末端与起点的距离超过 `3 × line_height` 后，若重锁判据看 caret 偏移，两帧会把锚点
+反复改成 `start → selection → start`。`QQ.exe` 的出厂规则启用 `composition_start_pair_guard`；仅当
+前帧确为 `TSF_COMPOSITION`、其 caret 等于本帧 reported compStart、且该点仍等于已锁起点时，
+后续 `TSF_SELECTION` 才被判成正常组合跨度而禁止重锁。UI 的右边界钳制只放大了观感，不是根因。
+
 ## 三、必测矩阵
 
 **每次改动候选窗定位相关代码，以下组合都要跑一遍。** 单个宿主全绿完全不能说明问题——本轮
-七个缺陷里，没有任何一个能在两个以上宿主上同时观察到。
+八个缺陷里，没有任何一个能在两个以上宿主上同时观察到。
 
 | # | 场景 | 必测宿主 | 看什么 |
 |---|---|---|---|
@@ -112,6 +132,7 @@ Excel、WPS 表格、EverEdit、记事本上暴露出**七种互不相同的错�
 | 6 | 长按同一键不放 | 记事本、EverEdit | 候选窗跟着文字走，不钉在原地 |
 | 7 | 极快速输入（脚本模拟 `d空格` 重复） | 记事本 | 候选窗仍出现（组合寿命可低至 19ms） |
 | 8 | 进单元格第一个字 | Excel、WPS 表格 | 一次到位，不先落在编辑栏/旧单元格 |
+| 9 | 长拼音持续输入，直到组合宽度超过 3 个行高 | QQNT | 候选窗始终锚在组合起点；不得在起点与末端间闪烁 |
 
 场景 5 的三种操作**必须分别测**：本轮位置启发式被连续推翻四次，每次都是被一个新的操作方向
 打掉的（字宽 → 换行 → 同行重排 → 退格），最后放弃位置判据、改成布尔判据才收敛。
@@ -138,6 +159,9 @@ caret_probe → 提前首显: ...
    说明缓存被 probe 抢先刷新了，基准问错了对象（见第一节）。
 4. **反复校正？** 同一个 `dx` 连续出现多条 `caret_update → reshow`，而 `pos` 不变——基准跟着显示
    位置走了。
+5. **起点与末端对打？** 相邻日志在 `src=tsf_composition` 与 `src=tsf_selection` 间交替，reported
+   `compStart` 不变，却出现 `组合起点重锁` 且 `UpdateCandidates pos=` 来回切换——把组合跨度误当成
+   起点错误了。
 
 一个统计口径的提醒：**连打时每打一个字光标本就前移一个字宽，随之而来的 reshow 是正确的跟随，
 不是漂移。** 统计漂移率时必须只看「首显后、下一次按键前」的位置变化，否则会把正常跟随算成缺陷
@@ -160,10 +184,13 @@ caret_probe → 提前首显: ...
 | `wind-coordinator/src/coordinator/first_show.rs` | 首显闸门、兜底 timer、`absorb_probe_coords` |
 | `wind-coordinator/src/coordinator/message_handler.rs` | `handle_caret_update` / `handle_caret_probe` |
 | `wind-coordinator/src/coordinator.rs` | `notify_ui_update` 里的位置计算与逃生口 |
-| `wind-config/src/app_compat.rs` | per-app 规则（`first_show_mode`、`caret_use_top`、`stale_probe_guard`） |
+| `wind-config/src/app_compat.rs` | per-app 规则（`first_show_mode`、`caret_use_top`、`stale_probe_guard`、`composition_start_pair_guard`） |
 | `data/compat.toml` | 出厂 per-app 规则 |
-| `wind_tsf/src/TextService.cpp` | `OnAsyncCaretRectReady`、probe 发送 |
+| `wind_tsf/src/CaretEditSession.cpp` | selection 无效时用 composition start 作 caret 的降级 |
+| `wind_tsf/src/TextService.cpp` | `OnAsyncCaretRectReady`、probe 发送与 caret source 标记 |
 
-> ⚠ 用户层 `%APPDATA%\WindInputDev\compat.toml` 的合并语义是「同名进程**整条**覆盖系统层」。
+> ⚠ 用户层 `%APPDATA%\WindInputDev\compat.toml` 的合并语义通常是「同名进程**整条**覆盖系统层」。
 > 排查「出厂规则不生效」时先看用户层有没有该进程的条目——菜单改回「跟随全局」曾会留下只剩
 > `process` 的空壳条目，把出厂规则整条屏蔽掉（已修：写盘时剔除空壳）。
+> `composition_start_pair_guard` 是协议级安全例外：用户层未写时继承出厂值，显式
+> `false` 才关闭，因而已有的 QQ 稀疏自定义规则不会让本修复在升级后失效。

--- a/docs/architecture/user-override.md
+++ b/docs/architecture/user-override.md
@@ -47,7 +47,12 @@
 | 文件 | 层次 | 实现 |
 |---|---|---|
 | `config.toml` | 代码默认 → `data/config.toml` → 用户 `config.toml` | `Config::load` |
-| `compat.toml` | `data/compat.toml` → 用户 `compat.toml`，按进程名整条覆盖 | `app_compat.rs::load` |
+| `compat.toml` | `data/compat.toml` → 用户 `compat.toml`，按进程名整条覆盖；协议修正 `composition_start_pair_guard` 未写时继承 | `app_compat.rs::load` |
+
+`composition_start_pair_guard` 的例外是为了升级安全：菜单会为某应用写只含被修改字段的
+稀疏用户规则，这不应该静默抹掉后续版本给该宿主新增的协议级正确性修正。该字段是
+`Option<bool>`：未写继承低层，显式 `false` 可覆盖关闭；其余 `compat.toml` 字段仍保持整条
+覆盖语义。
 
 附带一个只存在于用户侧、无安装目录对应物的合并层：`schema_overrides/{id}.toml`
 （设置页对方案参数的调整，深合并到方案文件之上）。它是**程序写、程序读**的，不是给用户

--- a/docs/redesign/candidate-window-positioning.md
+++ b/docs/redesign/candidate-window-positioning.md
@@ -227,6 +227,10 @@ UI 层（`wind-ui/src/candidate_window.rs`）**每帧据当前光标 + 内容尺
 
 - `coordinator.rs` 新增 `composition_start: Mutex<(x, y, valid)>`。
 - `handle_caret_update`：组合内首个有效 `compStart` 锁定（`!valid` 时才写），后续即便携带新值也不覆盖——防部分控件 `GetRange` 让起点随输入漂移；`<500px` 校验排除 logical/physical 坐标系不一致。
+- 首显锚点整体错误时允许按 caret 大偏移重锁。不能全局改成“reported compStart 非零就信它”：
+  其它宿主已有陈旧值和坐标系混用历史，会关闭原有自愈。对确认存在稳定帧对的宿主，以 per-app
+  `composition_start_pair_guard` 开启窄保护；只有来源顺序、前帧降级点、reported compStart 与当前锁
+  四者一致时，才把后续 selection 的大跨度判为正常组合宽度并保持起点。
 - `notify_ui_update` 坐标块：`in_app && compStart.valid` → 用 `compStart` 替代当前光标。
 - `reset_first_show`（组合结束/隐藏）复位 `valid=false`，下一组合重新锁定。
 - **`handle_focus_gained` 也复位**（2026-08-02）：焦点事件意味着换了 DocMgr，见下。
@@ -244,6 +248,13 @@ Excel 打破了它——输入时会在「单元格」与「公式编辑栏」�
 `state.caret_*` 判、下发却用锁死的组合起点，两者读的不是同一个值。
 
 故 `handle_focus_gained` 时作废锚定，由下一帧 `caret_update` 就地重锁。
+
+QQNT 提供了另一种反例：reported compStart 始终稳定，但同一按键后先报 selection 无效时的
+`TSF_COMPOSITION` 起点降级帧，再报真实的 `TSF_SELECTION` 组合末端。长拼音使末端离起点超过
+`3 × line_height` 后，若大偏移重锁以 caret 距离作证据，就会把两帧轮流写进
+`composition_start`，候选窗在起点与末端之间闪烁。出厂 `QQ.exe` 规则因此开启
+`composition_start_pair_guard`；协调器仅保护完整匹配的帧对，组合宽度增长不构成重锁理由，
+其它宿主仍保持原 caret 逃生阀。
 
 > **这个缺陷是被另一个修复"激活"的**：此前 Excel 的 `compStart` 取不到或被距离校验丢弃，
 > 锚定**从未真正生效**，候选窗一直跟着 caret 走，只表现为"跳一下"。修好 selection 退化降级与

--- a/wind_input/crates/wind-config/AGENTS.md
+++ b/wind_input/crates/wind-config/AGENTS.md
@@ -18,7 +18,7 @@
 | `src/variant.rs` | 运行时 dev/release/portable 判断：从 exe 文件名尾缀 `_dev` 判定（不依赖编译 profile）；`pipe_suffix` / `app_dir_name` / `is_portable` 供全仓使用；`WIND_VARIANT` 环境变量仅供开发覆盖。另含 `custom_userdata_dir`：读安装器写的 `datadir.conf` |
 | `src/runtime_state.rs` | `RuntimeState`（state.toml）：上次中英模式、工具栏位置（按显示器 key）、候选框 pin 位置；原子写（tmp+rename） |
 | `src/schema.rs` | `Schema` 方案定义（对应 `data/schemas/*.schema.toml`）：`SchemaInfo`/`EngineSpec`/`DictSpec` 等；与 config.toml 无关 |
-| `src/app_compat.rs` | `AppCompat`：按进程名（不区分大小写）匹配兼容规则（compat.toml，系统层+用户层合并），`get_rule` 返回 `Option<&AppCompatRule>` |
+| `src/app_compat.rs` | `AppCompat`：按进程名（不区分大小写）匹配兼容规则（compat.toml，系统层+用户层合并），`get_rule` 返回 `Option<&AppCompatRule>`；caret 宿主能力含 `caret_use_top` / `stale_probe_guard` / `composition_start_pair_guard`，后者是未写继承、显式 false 关闭的协议修正 |
 
 ## For AI Agents
 

--- a/wind_input/crates/wind-config/src/app_compat.rs
+++ b/wind_input/crates/wind-config/src/app_compat.rs
@@ -4,6 +4,8 @@
 //! 定位 / 光标获取等兼容修正。文件格式为 TOML 的 `[[apps]]` 数组表，加载顺序：
 //! 系统预置（`{data_dir}/compat.toml`）→ 定制版（`data_custom/compat.toml`）→
 //! 用户覆盖（`{user_config_dir}/compat.toml`），靠后层的同进程名规则整条覆盖靠前层。
+//! 唯一例外是宿主协议级的 `composition_start_pair_guard`：后层未写时继承，
+//! 显式 `false` 才关闭，避免菜单生成的稀疏规则无意抹掉已知宿主修复。
 
 use crate::config::SmartMethod;
 use serde::{Deserialize, Serialize};
@@ -25,6 +27,7 @@ const USER_COMPAT_HEADER: &str = "\
 #   手写的注释与排版不会保留。需要长期留存的说明请写在系统层 compat.toml。
 #
 # 合并语义：同名进程（不区分大小写）整条覆盖系统层，系统层其余规则保留。
+# 例外：composition_start_pair_guard 未写时继承系统层，显式 false 才关闭。
 # 字段说明见系统层 data/compat.toml 顶部注释。
 
 ";
@@ -191,6 +194,24 @@ pub struct AppCompatRule {
     /// 按宿主处理——与隔壁 `caret_use_top`（同样为微信而加）同一个理由。
     #[serde(default, skip_serializing_if = "is_false")]
     pub stale_probe_guard: bool,
+    /// 把连续的 `TSF_COMPOSITION`（selection 无效、以组合起点降级）→ `TSF_SELECTION`
+    /// 识别为同一次布局采样的两阶段结果，禁止后半帧把当前 caret 误重锁成组合起点。
+    ///
+    /// QQNT 实测：长组合里 reported compStart 始终稳定，但同一按键后的两帧 caret 会在
+    /// 组合起点与当前插入点之间跳变。两点距离超过大偏移阈值后，通用重锁逃生阀会把
+    /// `composition_start` 改成组合末端，下一次降级帧又改回起点，形成左右闪烁。
+    ///
+    /// ⚠ **必须逐宿主开启，不能全局信任非零 compStart**：其它宿主已有 compStart 陈旧、
+    /// logical/physical 坐标系混用的实测历史；全局改成“有 compStart 就以它为准”会关闭
+    /// 原有 caret 大偏移自愈，甚至把候选窗重锁到异常坐标。协调器还会核对来源顺序、
+    /// 前帧降级点、reported compStart 与当前锁四者一致，单独一个非零值不构成放行理由。
+    ///
+    /// **必须是 `Option<bool>`**：这是宿主协议级修正，不是一般用户偏好。用户可能已经
+    /// 通过菜单给 `QQ.exe` 写了只含 `first_show_mode` 的稀疏规则；若用 bool 的缺省
+    /// `false` 做整条覆盖，升级后会静默屏蔽系统层新增的 QQ 修复。`None` 表示继承
+    /// 低层，`Some(false)` 仍保留显式关闭的逃生口。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub composition_start_pair_guard: Option<bool>,
     /// 候选窗首显策略；`None` = 不干预，跟随全局 `ui.candidate.first_show_mode`。
     ///
     /// 三档互斥——做成枚举而不是几个 bool：布尔开关可以同时打开，实测就因此出过一次
@@ -681,9 +702,31 @@ fn load_file(path: &Path) -> Option<AppCompatFile> {
 
 /// 合并两组规则：user 中同名进程（不区分大小写）覆盖 base，其余 base 规则保留，
 /// 末尾追加全部 user 规则（与 Go `mergeCompatRules` 对齐）。
-fn merge_rules(base: Vec<AppCompatRule>, user: Vec<AppCompatRule>) -> Vec<AppCompatRule> {
+///
+/// 唯一字段级例外是 `composition_start_pair_guard`：它描述已确认的宿主 TSF 协议
+/// 形态，后层稀疏规则未写它时应继承低层；显式 `false` 仍可关闭。若照其它
+/// 字段用 `Default::default()` 的 `false` 整条覆盖，用户曾经从菜单写过的 QQ 规则会让
+/// 新版出厂修复永远无法生效。
+fn merge_rules(base: Vec<AppCompatRule>, mut user: Vec<AppCompatRule>) -> Vec<AppCompatRule> {
     if user.is_empty() {
         return base;
+    }
+    let inherited_pair_guards: HashMap<String, Option<bool>> = base
+        .iter()
+        .map(|r| {
+            (
+                r.process.to_ascii_lowercase(),
+                r.composition_start_pair_guard,
+            )
+        })
+        .collect();
+    for rule in &mut user {
+        if rule.composition_start_pair_guard.is_none() {
+            rule.composition_start_pair_guard = inherited_pair_guards
+                .get(&rule.process.to_ascii_lowercase())
+                .copied()
+                .flatten();
+        }
     }
     let user_keys: std::collections::HashSet<String> = user
         .iter()
@@ -788,6 +831,10 @@ mod tests {
             [[apps]]
             process = "plain.exe"
             caret_use_top = true
+
+            [[apps]]
+            process = "QQ.exe"
+            composition_start_pair_guard = true
         "#;
         let compat = AppCompat::from_rules(toml::from_str::<AppCompatFile>(toml).unwrap().apps);
 
@@ -805,6 +852,9 @@ mod tests {
         assert_eq!(plain.auto_pair, None);
         assert_eq!(plain.smart_method, None);
         assert_eq!((plain.caret_offset_x, plain.caret_offset_y), (0, 0));
+
+        let qq = compat.get_rule("qq.exe").unwrap();
+        assert_eq!(qq.composition_start_pair_guard, Some(true));
     }
 
     /// 写回只落被触碰的字段，且 `None`/0 不进 TOML（`skip_serializing_if`）——
@@ -867,6 +917,7 @@ mod tests {
         let compat = AppCompat::from_rules(file.apps);
         let rule = compat.get_rule("foo.exe").unwrap();
         assert!(!rule.caret_use_top);
+        assert_eq!(rule.composition_start_pair_guard, None);
         // 缺字段 = 不干预（跟随全局），与 initial_mode 同语义。若它退化成 Some(默认档)，
         // 等于给所有未配置的应用都写死了一份 per-app 覆盖，用户改全局默认时全部失效。
         assert_eq!(rule.first_show_mode, None);
@@ -937,6 +988,42 @@ mod tests {
         assert!(!merged.get_rule("Weixin.exe").unwrap().caret_use_top);
         // 合并后只剩一条（同进程去重）。
         assert_eq!(merged.apps.len(), 1);
+    }
+
+    /// `composition_start_pair_guard` 是已确认的宿主协议修正，不能因为用户
+    /// 曾经从菜单给同一应用写了另一个字段，就被稀疏规则的缺省值静默抹掉。
+    /// 同时保留显式 `false` 逃生口，新版宿主行为改变时不必改代码才能关闭。
+    #[test]
+    fn protocol_guard_inherits_through_sparse_override_but_false_can_disable_it() {
+        let base_rule = AppCompatRule {
+            process: "QQ.exe".into(),
+            composition_start_pair_guard: Some(true),
+            ..Default::default()
+        };
+        let sparse_user = AppCompatRule {
+            process: "qq.exe".into(),
+            first_show_mode: Some(FirstShowMode::Wait),
+            ..Default::default()
+        };
+        let merged = AppCompat::from_rules(merge_rules(vec![base_rule.clone()], vec![sparse_user]));
+        let inherited = merged.get_rule("QQ.exe").unwrap();
+        assert_eq!(inherited.composition_start_pair_guard, Some(true));
+        assert_eq!(inherited.first_show_mode, Some(FirstShowMode::Wait));
+
+        let explicit_off = AppCompatRule {
+            process: "qq.exe".into(),
+            composition_start_pair_guard: Some(false),
+            ..Default::default()
+        };
+        let merged = AppCompat::from_rules(merge_rules(vec![base_rule], vec![explicit_off]));
+        assert_eq!(
+            merged
+                .get_rule("QQ.exe")
+                .unwrap()
+                .composition_start_pair_guard,
+            Some(false),
+            "显式 false 必须压过系统层，作为宿主升级后的逃生口"
+        );
     }
 
     #[test]
@@ -1326,6 +1413,12 @@ mod tests {
         let file = load_file(&data_dir.join(COMPAT_FILE_NAME))
             .expect("随发布的 data/compat.toml 必须能解析（失败会静默吞掉全部规则）");
         let c = AppCompat::from_parts(file.apps, file.initial_mode_scope);
+
+        assert!(
+            c.get_rule("qq.exe")
+                .is_some_and(|r| r.composition_start_pair_guard == Some(true)),
+            "随发布的 QQ.exe 规则必须启用 composition_start_pair_guard"
+        );
 
         // 桌面：规则必须照常生效
         for class in ["Progman", "WorkerW"] {

--- a/wind_input/crates/wind-coordinator/src/coordinator.rs
+++ b/wind_input/crates/wind-coordinator/src/coordinator.rs
@@ -732,8 +732,8 @@ pub(crate) struct SmartSymbolArm {
 /// focus_gained / ime_activated 时按 `client_token` 高 32 位的 PID 解析进程名并缓存
 /// （见 `update_active_compat`），避免每次 caret 更新重复 OpenProcess。
 ///
-/// 用命名结构体而非元组：两个 bool 语义完全不同，`(u32, bool, bool)` 的 `.1`/`.2`
-/// 在调用点无从分辨——本仓已有多次「下标/名字与实际语义脱节」的返工。
+/// 用命名结构体而非元组：多个 bool 语义完全不同，元组下标在调用点无从分辨——本仓已有
+/// 多次「下标/名字与实际语义脱节」的返工。
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct ActiveCompat {
     /// 已解析的焦点进程 PID（0 = 尚未解析，此时其余字段无意义）。
@@ -744,6 +744,9 @@ pub(crate) struct ActiveCompat {
     /// 见 [`wind_config::app_compat::AppCompatRule::stale_probe_guard`]：
     /// 该宿主组合期间上报的 caret rect 会停在上一次组合的位置，需拦截。
     pub(crate) stale_probe_guard: bool,
+    /// 见 [`wind_config::app_compat::AppCompatRule::composition_start_pair_guard`]：
+    /// 该宿主会把组合起点降级帧与当前 selection 成对上报，后者不得触发大偏移重锁。
+    pub(crate) composition_start_pair_guard: bool,
     /// 候选窗首显策略（见 `AppCompatRule::first_show_mode`）。三档互斥；
     /// `None` = 跟随全局 `ui.candidate.first_show_mode`。
     ///
@@ -2417,6 +2420,9 @@ impl Coordinator {
                     pid,
                     caret_use_top: rule.map(|r| r.caret_use_top).unwrap_or(false),
                     stale_probe_guard: rule.map(|r| r.stale_probe_guard).unwrap_or(false),
+                    composition_start_pair_guard: rule
+                        .and_then(|r| r.composition_start_pair_guard)
+                        .unwrap_or(false),
                     first_show_mode: rule.and_then(|r| r.first_show_mode),
                     has_initial_rule: initial_mode.is_some() || initial_punct.is_some(),
                     auto_pair: rule.and_then(|r| r.auto_pair),
@@ -2433,9 +2439,11 @@ impl Coordinator {
         // 规则未命中与「命中但全 false」在日志里无从区分，查「某应用兼容项没生效」时看不到
         // 究竟是没匹配上进程名还是字段没读到。
         debug!(
-            "Compat rule for process={name}: matched={} caret_use_top={} first_show_mode={} initial_mode={} initial_punct={} auto_pair={} smart_method={} caret_offset=({},{})",
+            "Compat rule for process={name}: matched={} caret_use_top={} stale_probe_guard={} composition_start_pair_guard={} first_show_mode={} initial_mode={} initial_punct={} auto_pair={} smart_method={} caret_offset=({},{})",
             rule_matched,
             next.caret_use_top,
+            next.stale_probe_guard,
+            next.composition_start_pair_guard,
             next.first_show_mode
                 .map(|m| m.as_config())
                 .unwrap_or("(follow-global)"),
@@ -2524,7 +2532,8 @@ impl Coordinator {
     }
 
     /// 只刷新 `active_compat` 里「当前生效设置」那一半字段（`caret_use_top` /
-    /// `first_show_mode` / `auto_pair` / `smart_method` / `caret_offset_*`），**刻意不碰
+    /// `stale_probe_guard` / `composition_start_pair_guard` / `first_show_mode` / `auto_pair` /
+    /// `smart_method` / `caret_offset_*`），**刻意不碰
     /// `.pid` 与 `.has_initial_rule`**。
     ///
     /// 这两个字段的另一重身份是「上一次真实 `FOCUS_GAINED` 落在哪个进程」——
@@ -2561,6 +2570,7 @@ impl Coordinator {
         let (
             caret_use_top,
             stale_probe_guard,
+            composition_start_pair_guard,
             first_show_mode,
             auto_pair,
             smart_method,
@@ -2572,6 +2582,8 @@ impl Coordinator {
             (
                 rule.map(|r| r.caret_use_top).unwrap_or(false),
                 rule.map(|r| r.stale_probe_guard).unwrap_or(false),
+                rule.and_then(|r| r.composition_start_pair_guard)
+                    .unwrap_or(false),
                 rule.and_then(|r| r.first_show_mode),
                 rule.and_then(|r| r.auto_pair),
                 rule.and_then(|r| r.smart_method),
@@ -2580,7 +2592,7 @@ impl Coordinator {
             )
         };
         debug!(
-            "Connected-pid compat refresh for process={name} (pid={pid}): caret_use_top={} stale_probe_guard={stale_probe_guard} first_show_mode={} auto_pair={} smart_method={} caret_offset=({},{})",
+            "Connected-pid compat refresh for process={name} (pid={pid}): caret_use_top={} stale_probe_guard={stale_probe_guard} composition_start_pair_guard={composition_start_pair_guard} first_show_mode={} auto_pair={} smart_method={} caret_offset=({},{})",
             caret_use_top,
             first_show_mode
                 .map(|m| m.as_config())
@@ -2602,6 +2614,7 @@ impl Coordinator {
             let mut ac = self.active_compat.lock().unwrap_or_else(|e| e.into_inner());
             ac.caret_use_top = caret_use_top;
             ac.stale_probe_guard = stale_probe_guard;
+            ac.composition_start_pair_guard = composition_start_pair_guard;
             ac.first_show_mode = first_show_mode;
             ac.auto_pair = auto_pair;
             ac.smart_method = smart_method;
@@ -5072,12 +5085,12 @@ impl Coordinator {
         // 把候选窗从首显处挪到组合起点——而上一行 `settle` 刚判定这 13px 不值得校正。排在
         // `cs.2` 后面等于让组合起点从侧面绕过 settle，悬停一次就补上那 13px。
         // 真正该动候选窗的两种情形（首显、坐标校正）都不满足 `hold_anchor`，照常走下面两条。
-        let (cx, cy, ch) = if hold_anchor {
-            (anchor.0, anchor.1, state.caret_height)
+        let (cx, cy, ch, anchor_source) = if hold_anchor {
+            (anchor.0, anchor.1, state.caret_height, "shown_anchor")
         } else if in_app && cs.2 {
-            (cs.0, cs.1, state.caret_height)
+            (cs.0, cs.1, state.caret_height, "composition_start")
         } else {
-            (state.caret_x, state.caret_y, state.caret_height)
+            (state.caret_x, state.caret_y, state.caret_height, "caret")
         };
         let (caret_x, caret_y, caret_height, caret_valid) = self.resolve_caret_for_ui(cx, cy, ch);
         let n_items = items.len();
@@ -5132,9 +5145,17 @@ impl Coordinator {
         #[cfg(target_os = "macos")]
         self.push_candidate_menu_flags(state, start, end);
         tracing::debug!(
-            "notify_ui_update: build+send {:?} (n={})",
+            "notify_ui_update: build+send {:?} (n={n_items}) pos=({caret_x},{caret_y}) h={caret_height} \
+             valid={caret_valid} anchor={anchor_source} raw=({cx},{cy}) hold={hold_anchor} \
+             first={is_first_frame} authorized={authorized} in_app={in_app} \
+             compStart=({},{},valid={}) shownAnchor=({},{},valid={}) fixed={cand_fixed}",
             t_nu.elapsed(),
-            n_items
+            cs.0,
+            cs.1,
+            cs.2,
+            anchor.0,
+            anchor.1,
+            anchor.2,
         );
     }
 
@@ -5506,11 +5527,18 @@ impl Coordinator {
     ///
     /// 组合起点坐标同步平移以保持锚点一致；为 0（未提供）时不动，避免把「没有值」
     /// 变成「一个偏移后的假值」。
-    fn apply_caret_compat(&self, data: &mut CaretData) {
-        let (use_top, dx, dy) = {
-            let ac = self.active_compat.lock().unwrap_or_else(|e| e.into_inner());
-            (ac.caret_use_top, ac.caret_offset_x, ac.caret_offset_y)
-        };
+    /// 对 caret 应用当前宿主兼容变换，并返回与本次变换**同一时刻**的规则快照。
+    ///
+    /// 高频 caret 路径后续还要判断宿主协议帧对；若变换后再锁一次 `active_compat`，焦点恰在
+    /// 两次取锁之间切换时就可能拿到两个宿主的规则拼盘。返回 Copy 快照既少一次锁，也让
+    /// 本帧所有兼容判据共享同一来源。
+    fn apply_caret_compat(&self, data: &mut CaretData) -> ActiveCompat {
+        let active = *self.active_compat.lock().unwrap_or_else(|e| e.into_inner());
+        let (use_top, dx, dy) = (
+            active.caret_use_top,
+            active.caret_offset_x,
+            active.caret_offset_y,
+        );
         if use_top && data.height > 0 {
             let raw_h = data.height;
             data.y -= raw_h;
@@ -5523,6 +5551,7 @@ impl Coordinator {
             let scale = dpi_scale_for_point(data.x, data.y);
             apply_dp_offset(data, dx, dy, scale);
         }
+        active
     }
 
     fn apply_focus_caret(&self, data: &CaretData, via: &str) {
@@ -5555,7 +5584,7 @@ impl Coordinator {
     /// 从而永远走回退分支——症状与本次要修的「气泡永远在主屏」一模一样。
     /// 上界 32000 只用于挡住 i32 溢出级的脏数据（宿主偶发上报的未初始化值）。
     fn caret_is_valid(x: i32, y: i32, height: i32) -> bool {
-        height > 0 && !(x == 0 && y == 0) && x.abs() < 32000 && y.abs() < 32000
+        height > 0 && !(x == 0 && y == 0) && x > -32000 && x < 32000 && y > -32000 && y < 32000
     }
 
     /// 解析「用于 UI 定位」的光标坐标：无效坐标回退到最近一次有效坐标。
@@ -7089,6 +7118,24 @@ mod caret_compat_tests {
     }
 
     #[test]
+    fn overflow_sentinel_composition_start_is_rejected_without_panicking() {
+        let c = coord();
+        c.state.lock().unwrap().input_buffer = "ab".to_string();
+        c.handle_caret_update(&CaretData {
+            x: 100,
+            y: 200,
+            height: 20,
+            composition_start_x: i32::MIN,
+            composition_start_y: 200,
+            source: wind_ipc::protocol::caret_source::TSF_SELECTION,
+        });
+        assert!(
+            !c.composition_start.lock().unwrap().2,
+            "i32::MIN 级脏数据必须被距绝，不得在距离计算中溢出 panic"
+        );
+    }
+
+    #[test]
     fn caret_use_top_shifts_y_to_top_and_keeps_real_line_height() {
         let c = coord();
         // 模拟焦点进程命中 caret_use_top 规则。
@@ -7952,19 +7999,24 @@ mod caret_compat_tests {
         );
     }
 
-    /// 取最近一条 `UpdateCandidates` 下发的位置。
-    fn last_pos(rx: &std::sync::mpsc::Receiver<UiCommand>) -> Option<(i32, i32)> {
-        let mut found = None;
-        // 排空取**最后**一条：一次刷新会发多条 UI 命令
+    /// 排空并取全部 `UpdateCandidates` 下发位置。
+    fn drain_positions(rx: &std::sync::mpsc::Receiver<UiCommand>) -> Vec<(i32, i32)> {
+        let mut found = Vec::new();
         while let Ok(cmd) = rx.try_recv() {
             if let UiCommand::UpdateCandidates {
                 caret_x, caret_y, ..
             } = cmd
             {
-                found = Some((caret_x, caret_y));
+                found.push((caret_x, caret_y));
             }
         }
         found
+    }
+
+    /// 取最近一条 `UpdateCandidates` 下发的位置。
+    fn last_pos(rx: &std::sync::mpsc::Receiver<UiCommand>) -> Option<(i32, i32)> {
+        // 排空取**最后**一条：一次刷新会发多条 UI 命令
+        drain_positions(rx).last().copied()
     }
 
     /// ★★ 非坐标原因的重绘不得移动候选窗。`state.caret_x/y` 是缓存，会被 probe 的
@@ -8332,36 +8384,231 @@ mod caret_compat_tests {
     /// 判据是**量级**不是方向：字宽差异恒在一个行高上下，真实错位差一个数量级。
     #[test]
     fn a_grossly_wrong_first_show_can_relock_the_composition_start() {
+        // QQ 修复是显式 per-app 帧对保护，未开启时大偏移逃生阀必须保持原行为：无论宿主
+        // 报的是新 compStart、没有 compStart，还是继续回显陈旧 compStart，都以当前 caret
+        // 自愈。否则会让微信/WPS/EverEdit/Excel 的历史错锚点重新变成不可撤销。
+        for (case, reported_cs_x) in [
+            ("新 compStart", 493),
+            ("缺失 compStart", 0),
+            ("陈旧 compStart", 1030),
+        ] {
+            let (c, rx) = Coordinator::new_headless_with_ui(Config::default(), None);
+            set_mode(&c, wind_config::app_compat::FirstShowMode::Instant);
+            *c.last_valid_caret.lock().unwrap() = (1030, 987, 20);
+            c.last_sane_caret_height
+                .store(20, std::sync::atomic::Ordering::Relaxed);
+            {
+                let mut st = c.state.lock().unwrap();
+                st.input_buffer = "a".into();
+                st.candidates = vec![wind_candidate::Candidate {
+                    text: "测".into(),
+                    ..Default::default()
+                }];
+                st.caret_x = 1030;
+                st.caret_y = 987;
+                st.caret_height = 20;
+            }
+            {
+                let st = c.state.lock().unwrap();
+                c.notify_ui_update(&st);
+            }
+            assert_eq!(last_pos(&rx), Some((1030, 987)), "首显于陈旧坐标");
+            // 首显那一刻把它锁成了组合起点（idle_anchor 路径的行为）
+            *c.composition_start.lock().unwrap() = (1030, 987, true);
+
+            // 真实插入点在 537px 之外——远超字宽量级，说明首显位置整个是错的
+            let mut update = probe_at(493, 988, 20);
+            update.composition_start_x = reported_cs_x;
+            if reported_cs_x == 0 {
+                update.composition_start_y = 0;
+            }
+            c.handle_caret_update(&update);
+            assert_eq!(
+                last_pos(&rx),
+                Some((493, 988)),
+                "偏移远超字宽量级时组合起点必须重锁，否则候选窗永远停在错处；\
+                 case={case}"
+            );
+        }
+    }
+
+    /// ★★★ QQNT 的嵌入组合会在同一按键后依次上报两种 TSF 坐标：selection 暂时无效时，
+    /// DLL 用稳定的组合起点降级成 caret（`TSF_COMPOSITION`）；紧接着 selection 恢复，caret
+    /// 回到正在向右增长的当前插入点（`TSF_SELECTION`），而 reported compStart 始终没动。
+    ///
+    /// 长拼音令「当前插入点 - 组合起点」自然超过 3 个行高后，若大偏移逃生阀拿 caret 偏移
+    /// 判断“组合起点是否锁错”，两种帧就会把锚点反复重锁成 `start → selection → start`，
+    /// 候选窗随之左右闪烁。组合跨度不是起点错误；reported compStart 没动就必须继续钉住。
+    #[test]
+    fn long_qq_composition_does_not_oscillate_between_start_and_selection() {
+        const START_X: i32 = 598;
+        const Y: i32 = 585;
+        const LINE_H: i32 = 18;
+
         let (c, rx) = Coordinator::new_headless_with_ui(Config::default(), None);
         set_mode(&c, wind_config::app_compat::FirstShowMode::Instant);
-        *c.last_valid_caret.lock().unwrap() = (1030, 987, 20);
+        c.active_compat.lock().unwrap().composition_start_pair_guard = true;
+        *c.last_valid_caret.lock().unwrap() = (START_X, Y, LINE_H);
         c.last_sane_caret_height
-            .store(20, std::sync::atomic::Ordering::Relaxed);
+            .store(LINE_H, std::sync::atomic::Ordering::Relaxed);
         {
             let mut st = c.state.lock().unwrap();
-            st.input_buffer = "a".into();
+            st.input_buffer = "daduo".into();
             st.candidates = vec![wind_candidate::Candidate {
                 text: "测".into(),
                 ..Default::default()
             }];
-            st.caret_x = 1030;
-            st.caret_y = 987;
-            st.caret_height = 20;
+            st.caret_x = START_X;
+            st.caret_y = Y;
+            st.caret_height = LINE_H;
         }
         {
             let st = c.state.lock().unwrap();
             c.notify_ui_update(&st);
         }
-        assert_eq!(last_pos(&rx), Some((1030, 987)), "首显于陈旧坐标");
-        // 首显那一刻把它锁成了组合起点（idle_anchor 路径的行为）
-        *c.composition_start.lock().unwrap() = (1030, 987, true);
+        assert_eq!(last_pos(&rx), Some((START_X, Y)), "首显于组合起点");
+        *c.composition_start.lock().unwrap() = (START_X, Y, true);
+        // 真机跨过阈值前的上一帧 selection caret 是 644；第一对帧随后是 start=598、selection=653。
+        *c.caret_baseline.lock().unwrap() = (644, Y, true);
 
-        // 真实插入点在 537px 之外——远超字宽量级，说明首显位置整个是错的
-        c.handle_caret_update(&probe_at(493, 988, 20));
+        for selection_x in [653, 662, 670, 682] {
+            c.handle_caret_update(&CaretData {
+                x: START_X,
+                y: Y,
+                height: LINE_H,
+                composition_start_x: START_X,
+                composition_start_y: Y,
+                source: wind_ipc::protocol::caret_source::TSF_COMPOSITION,
+            });
+            assert!(
+                drain_positions(&rx)
+                    .into_iter()
+                    .all(|pos| pos == (START_X, Y)),
+                "组合起点降级帧即使触发重绘，下发位置也只能是原起点"
+            );
+
+            c.handle_caret_update(&CaretData {
+                x: selection_x,
+                y: Y,
+                height: LINE_H,
+                composition_start_x: START_X,
+                composition_start_y: Y,
+                source: wind_ipc::protocol::caret_source::TSF_SELECTION,
+            });
+            assert!(
+                drain_positions(&rx)
+                    .into_iter()
+                    .all(|pos| pos == (START_X, Y)),
+                "selection caret 只是组合末端；允许抑制重复重绘，但不得下发其它位置"
+            );
+            assert_eq!(
+                *c.composition_start.lock().unwrap(),
+                (START_X, Y, true),
+                "reported compStart 未变化时，同一组合的锚点必须保持不变"
+            );
+        }
+    }
+
+    /// `composition_start_pair_guard` 必须是按宿主开启的窄保护，默认行为一字不差。
+    ///
+    /// 同一组 QQ 坐标若没有 compat 证据，协调器无法知道“稳定 compStart”与“陈旧 compStart”
+    /// 哪个是真的；此时必须保留已有 caret 大偏移逃生阀，不能让单宿主修复改变全局语义。
+    #[test]
+    fn composition_start_pair_guard_is_per_app_and_off_by_default() {
+        const START_X: i32 = 598;
+        const Y: i32 = 585;
+        const LINE_H: i32 = 18;
+
+        let (c, rx) = Coordinator::new_headless_with_ui(Config::default(), None);
+        set_mode(&c, wind_config::app_compat::FirstShowMode::Instant);
+        {
+            let mut st = c.state.lock().unwrap();
+            st.input_buffer = "daduo".into();
+            st.candidates = vec![wind_candidate::Candidate {
+                text: "测".into(),
+                ..Default::default()
+            }];
+            st.caret_x = 644;
+            st.caret_y = Y;
+            st.caret_height = LINE_H;
+        }
+        *c.composition_start.lock().unwrap() = (START_X, Y, true);
+        *c.caret_baseline.lock().unwrap() = (644, Y, true);
+        *c.candidate_shown.lock().unwrap() = true;
+        c.last_sane_caret_height
+            .store(LINE_H, std::sync::atomic::Ordering::Relaxed);
+
+        c.handle_caret_update(&CaretData {
+            x: START_X,
+            y: Y,
+            height: LINE_H,
+            composition_start_x: START_X,
+            composition_start_y: Y,
+            source: wind_ipc::protocol::caret_source::TSF_COMPOSITION,
+        });
+        let _ = drain_positions(&rx);
+        c.handle_caret_update(&CaretData {
+            x: 653,
+            y: Y,
+            height: LINE_H,
+            composition_start_x: START_X,
+            composition_start_y: Y,
+            source: wind_ipc::protocol::caret_source::TSF_SELECTION,
+        });
+
         assert_eq!(
-            last_pos(&rx),
-            Some((493, 988)),
-            "偏移远超字宽量级时组合起点必须重锁，否则候选窗永远停在错处"
+            *c.composition_start.lock().unwrap(),
+            (653, Y, true),
+            "未命中 compat 时须保留原 caret 重锁语义，不能全局信任 reported compStart"
+        );
+    }
+
+    /// compat 保护只认完整、可信的帧对。异常 compStart 不得成为重锁目标；无法确认帧对时
+    /// 回到旧 caret 逃生阀，至少候选窗仍能落在已经通过 `now_valid` 的当前插入点。
+    #[test]
+    fn composition_start_pair_guard_never_relocks_to_invalid_reported_start() {
+        const START_X: i32 = 598;
+        const Y: i32 = 585;
+        const LINE_H: i32 = 18;
+
+        let (c, rx) = Coordinator::new_headless_with_ui(Config::default(), None);
+        set_mode(&c, wind_config::app_compat::FirstShowMode::Instant);
+        c.active_compat.lock().unwrap().composition_start_pair_guard = true;
+        {
+            let mut st = c.state.lock().unwrap();
+            st.input_buffer = "daduo".into();
+            st.candidates = vec![wind_candidate::Candidate {
+                text: "测".into(),
+                ..Default::default()
+            }];
+            st.caret_x = START_X;
+            st.caret_y = Y;
+            st.caret_height = LINE_H;
+            st.caret_source = wind_ipc::protocol::caret_source::TSF_COMPOSITION;
+        }
+        *c.composition_start.lock().unwrap() = (START_X, Y, true);
+        *c.caret_baseline.lock().unwrap() = (START_X, Y, true);
+        *c.candidate_shown.lock().unwrap() = true;
+        c.last_sane_caret_height
+            .store(LINE_H, std::sync::atomic::Ordering::Relaxed);
+
+        c.handle_caret_update(&CaretData {
+            x: 653,
+            y: Y,
+            height: LINE_H,
+            composition_start_x: i32::MIN,
+            composition_start_y: Y,
+            source: wind_ipc::protocol::caret_source::TSF_SELECTION,
+        });
+
+        assert_eq!(
+            *c.composition_start.lock().unwrap(),
+            (653, Y, true),
+            "溢出级异常 reported compStart 不得成为锚点；帧对不可信时退回已校验的 caret"
+        );
+        assert!(
+            drain_positions(&rx).into_iter().all(|pos| pos == (653, Y)),
+            "任何下发都不得携带异常 reported compStart"
         );
     }
 
@@ -9224,6 +9471,7 @@ mod caret_compat_tests {
             .insert(pid, "alacritty.exe".to_string());
         let mut rules = Vec::new();
         wind_config::app_compat::set_caret_offset(&mut rules, "alacritty.exe", 0, 12);
+        rules[0].composition_start_pair_guard = Some(true);
         *c.app_compat.lock().unwrap() = wind_config::app_compat::AppCompat::from_rules(rules);
 
         c.apply_connected_pid_compat(pid, pid);
@@ -9232,6 +9480,10 @@ mod caret_compat_tests {
             c.active_compat.lock().unwrap().caret_offset_y,
             12,
             "该 pid 确认在前台时，连接建立即应解析出它的 per-app 规则字段"
+        );
+        assert!(
+            c.active_compat.lock().unwrap().composition_start_pair_guard,
+            "连接恢复路径也必须刷新 composition_start_pair_guard"
         );
     }
 
@@ -9326,6 +9578,28 @@ mod caret_compat_tests {
             c.active_compat.lock().unwrap().first_show_mode,
             Some(wind_config::app_compat::FirstShowMode::Fast),
             "缓存里的 bundle id 必须参与 compat 规则匹配"
+        );
+    }
+
+    #[test]
+    fn update_active_compat_loads_composition_start_pair_guard() {
+        let c = coord();
+        let pid = 5151u32;
+        let token = (pid as u64) << 32 | 4;
+        c.pid_names.lock().unwrap().insert(pid, "qq.exe".into());
+        *c.app_compat.lock().unwrap() = wind_config::app_compat::AppCompat::from_rules(vec![
+            wind_config::app_compat::AppCompatRule {
+                process: "QQ.exe".into(),
+                composition_start_pair_guard: Some(true),
+                ..Default::default()
+            },
+        ]);
+
+        c.update_active_compat(token);
+
+        assert!(
+            c.active_compat.lock().unwrap().composition_start_pair_guard,
+            "焦点路径必须把 QQ 的帧对保护从 compat 规则接入热路径"
         );
     }
 }
@@ -11318,6 +11592,10 @@ mod caret_for_ui_tests {
             "height=0 = 宿主尚未 reflow，整组坐标不可信"
         );
         assert!(!Coordinator::caret_is_valid(40000, 500, 20), "越界脏数据");
+        assert!(
+            !Coordinator::caret_is_valid(i32::MIN, 500, 20),
+            "未初始化极值必须安全判无效，不得在 abs() 溢出"
+        );
     }
 
     /// ★ 修复核心：无效坐标必须回退到最近一次有效坐标，且该坐标可以在副屏（负值）。

--- a/wind_input/crates/wind-coordinator/src/coordinator/message_handler.rs
+++ b/wind_input/crates/wind-coordinator/src/coordinator/message_handler.rs
@@ -2459,10 +2459,16 @@ impl MessageHandler for Coordinator {
         // 让上方显示正确避让正文（偏大只是多留空隙，偏小才会遮挡——宁大勿小）。
         // 组合起点 Y 同步上移以保持锚点一致。后续逻辑全部基于变换后的本地副本。
         let mut data = *data;
-        self.apply_caret_compat(&mut data);
+        let active_compat = self.apply_caret_compat(&mut data);
         let data = &data;
+        let composition_start_pair_guard = active_compat.composition_start_pair_guard;
         let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
-        let (prev_x, prev_y) = (state.caret_x, state.caret_y);
+        let (prev_x, prev_y, prev_height, prev_source) = (
+            state.caret_x,
+            state.caret_y,
+            state.caret_height,
+            state.caret_source,
+        );
         state.caret_x = data.x;
         state.caret_y = data.y;
         state.caret_height = data.height;
@@ -2473,10 +2479,9 @@ impl MessageHandler for Coordinator {
                 .store(data.height, std::sync::atomic::Ordering::Relaxed);
         }
         state.caret_source = data.source;
-        let now_valid =
-            !(data.x == 0 && data.y == 0) && data.x.abs() < 32000 && data.y.abs() < 32000;
+        let now_valid = Self::caret_is_valid(data.x, data.y, data.height);
         if !now_valid {
-            debug!("caret_update → 丢弃: 坐标无效（(0,0) 哨兵或越界）");
+            debug!("caret_update → 丢弃: caret 无效（(0,0) 哨兵、越界或高度非正）");
             return;
         }
         // 消费焦点气泡的挂起：DLL 在焦点路径拿不到同步锁时会异步补一条权威坐标，这就是它。
@@ -2548,8 +2553,10 @@ impl MessageHandler for Coordinator {
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
             if !cs.2 && (data.composition_start_x != 0 || data.composition_start_y != 0) {
-                let dx = (data.composition_start_x - data.x).abs();
-                let dy = (data.composition_start_y - data.y).abs();
+                // 先扩到 i64 再减：宿主未初始化的 compStart 可能是 i32::MIN，
+                // 直接 i32 相减 / abs 会在 debug 构建中溢出 panic，连“丢弃脏数据”都走不到。
+                let dx = (i64::from(data.composition_start_x) - i64::from(data.x)).abs();
+                let dy = (i64::from(data.composition_start_y) - i64::from(data.y)).abs();
                 // ⚠ 500px 校验的前提是**两者同源**——它想抓的是「同一个 context 报出的两个坐标
                 // 却相差离谱」这种坐标系不一致。当 caret 本身来自 GUI 回退等非 TSF 通道时，
                 // 它和组合起点压根不是一个语义域，比较毫无意义。桌面输入实测：caret=(0,1388)
@@ -2738,16 +2745,23 @@ impl MessageHandler for Coordinator {
             // 取那个锁死的组合起点。微信实测「删除几个字符后再输入，候选窗停在删除前的位置」、
             // EverEdit 447px、WPS 277px、Excel 1443px，全是这一种。
             //
-            // 判据是**量级**而不是方向：字宽差异恒在一个行高上下（一个中文字符宽 ≈ 行高），
-            // 而真实错位实测 277~1443px，差一个数量级。取 3 倍行高作界，两边都留足余量。
+            // 默认判据仍是当前 caret 的**量级**，真实错位实测 277~1443px，取 3 倍行高作界。
+            // 不能全局改成“reported compStart 非零就信它”：微信/WPS 等已有 compStart 陈旧、
+            // logical/physical 坐标系混用的历史，那会关闭本逃生阀，甚至把锚点写到异常位置。
+            //
+            // QQNT 是按宿主开启的窄例外。实测同一按键先报 `TSF_COMPOSITION`（selection 暂时
+            // 无效，DLL 用稳定起点降级成 caret）、紧接着报当前 `TSF_SELECTION`；两帧 reported
+            // compStart 始终等于已锁起点。长拼音一旦超过 3 个行高，后半帧的 caret 只是正常
+            // 组合跨度，不是起点锁错。只有同时满足以下四项才抑制这次重锁：compat 明确开启、
+            // 来源顺序正确、前帧降级 caret 等于本帧 reported compStart、它也等于当前锁。
+            // 单独一个非零 compStart 没有任何特权。
             // ⚠ 这不是那种被推翻过四次的位置启发式——那些判的是「这一帧的方向对不对」，
             // 依赖光标往哪走；这里判的是「差得离不离谱」，与方向无关。
             //
             // ⚠ **已知盲区**：偏差落在 `tol_x`（≈2 倍行高）与 `3 倍行高`之间时，reshow 会触发
             // 但位置仍取被钉住的组合起点——校正白跑一次，错位持续存在。阈值再往下调会把组合
-            // 内「光标随每个字母前移」那些 reshow 也算进来（实测 dx=13/14 连续出现），组合起点
-            // 就会跟着输入右移，候选窗一格一格挪——那是更明显的缺陷。这段区间对应「缓存差了
-            // 两个字符宽」，实测未遇到；真出现的话要换判据，不是调这个数。
+            // 内普通逐字前移也算成错锚点（微信实测 dx=13/14），让起点逐格右移。真遇到该区间
+            // 要换证据，不是继续调数值。
             {
                 let line_h = self
                     .last_sane_caret_height
@@ -2760,12 +2774,40 @@ impl MessageHandler for Coordinator {
                         .lock()
                         .unwrap_or_else(|e| e.into_inner());
                     if cs.2 {
-                        debug!(
-                            "组合起点重锁: ({},{}) → ({},{})（偏移 {}/{} 远超字宽量级，\
-                             首显位置整个是错的，不能再钉住）",
-                            cs.0, cs.1, data.x, data.y, dx, dy
-                        );
-                        *cs = (data.x, data.y, true);
+                        let guarded_pair = composition_start_pair_guard
+                            && prev_source == wind_ipc::protocol::caret_source::TSF_COMPOSITION
+                            && data.source == wind_ipc::protocol::caret_source::TSF_SELECTION
+                            && Self::caret_is_valid(prev_x, prev_y, prev_height)
+                            && Self::caret_is_valid(
+                                data.composition_start_x,
+                                data.composition_start_y,
+                                data.height,
+                            )
+                            && (prev_x, prev_y)
+                                == (data.composition_start_x, data.composition_start_y)
+                            && (cs.0, cs.1) == (data.composition_start_x, data.composition_start_y);
+                        if guarded_pair {
+                            debug!(
+                                "组合起点保持: ({},{})（命中 composition_start_pair_guard：\
+                                 prev=({prev_x},{prev_y}) h={prev_height} src={}，current=({},{}) src={}，\
+                                 compStart=({},{})；caret 跨度 {dx}/{dy} 不是起点错误）",
+                                cs.0,
+                                cs.1,
+                                wind_ipc::protocol::caret_source::name(prev_source),
+                                data.x,
+                                data.y,
+                                wind_ipc::protocol::caret_source::name(data.source),
+                                data.composition_start_x,
+                                data.composition_start_y
+                            );
+                        } else if (cs.0, cs.1) != (data.x, data.y) {
+                            debug!(
+                                "组合起点重锁: ({},{}) → ({},{})（caret 偏移 {dx}/{dy} \
+                                 远超字宽量级，首显位置整个是错的，不能再钉住）",
+                                cs.0, cs.1, data.x, data.y
+                            );
+                            *cs = (data.x, data.y, true);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 变更说明

修复 QQNT（`QQ.exe`，`Chrome_WidgetWin_1`）聊天输入框中，长拼音连续输入时候选窗在组合起点与当前插入点之间左右闪烁的问题。

### 根因

QQNT 在同一按键后会先发送 selection 暂时无效的 `TSF_COMPOSITION` 坐标（DLL 退化为稳定的组合起点），随后发送当前 `TSF_SELECTION` 坐标；两帧携带的 reported composition start 始终不变。长组合的正常宽度超过 `3 * line_h` 后，现有“大偏移重锁”逃生阀会把 selection caret 误判为新的组合起点。下一次 `TSF_COMPOSITION` 又把坐标带回真实起点，于是锚点在 `composition_start -> selection -> composition_start` 之间振荡。

本次修复维护的不变式是：**同一组合内，在 reported composition start 稳定且 QQNT 帧对证据完整时，候选 UI 锚点不得因正常组合跨度超过大偏移阈值而切换到 selection caret。**

时序变为：

`按键 -> TSF_COMPOSITION(start) -> caret_update -> TSF_SELECTION(current, same start) -> pair guard 保持 start -> notify_ui_update(start) -> place_window`。

### 处理方式

- 在 `compat.toml` 为 `QQ.exe` 启用 `composition_start_pair_guard`，不改变其他宿主的默认恢复逻辑。
- 仅当 compat 开启、来源顺序为 `TSF_COMPOSITION -> TSF_SELECTION`、前帧降级点等于本帧 reported start、reported start 又等于当前锁定起点时，才抑制大偏移重锁。
- reported start 无效或帧对不完整时仍回退到原有 caret 重锁逻辑，避免关闭微信/WPS/Excel 等宿主依赖的错位逃生阀。
- 让该协议修正可穿过用户层的稀疏 QQ 规则继承；用户显式写 `false` 时仍可关闭。
- 增加 debug 诊断日志、配置/刷新路径测试，并同步候选窗定位与宿主兼容文档。

### 回归覆盖

- `long_qq_composition_does_not_oscillate_between_start_and_selection`
- `composition_start_pair_guard_is_per_app_and_off_by_default`
- `composition_start_pair_guard_never_relocks_to_invalid_reported_start`
- `update_active_compat_loads_composition_start_pair_guard`
- 保留并通过既有微信/错误首显/settle 回归测试。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构 / 代码优化
- [x] 文档更新
- [ ] 构建 / CI 相关
- [ ] 其他（请说明）

## 相关 Issue

无；依据 QQ 真机录屏、TSF/core debug 日志与本地复现定位。

## 测试情况

- [x] 已在 Windows 10/11 上测试
- [ ] 已在 macOS 上测试（如涉及）
- [x] 已测试相关输入方案（五笔/拼音/混输）
- [x] `.\scripts\dev.ps1 ci` 通过（fmt 检查 + clippy + 测试）

补充验证：

- stable 1.98.1 下 `cargo test --workspace` 全量通过。
- stable 1.98.1 下 `cargo clippy --workspace --all-targets -- -D warnings` 通过。
- `cargo check-headless` 通过（仅有上游已有的 `push_refresh_icon` dead-code warning）。
- release 二进制已构建并替换本机安装；QQ 长拼音连续输入真机复测不再闪烁。

## 检查清单

- [x] Rust 代码已用 `cargo fmt` 格式化（本次未产生独立纯格式差异）
- [x] 提交信息遵循 [Conventional Commits](https://www.conventionalcommits.org/) 规范
- [x] 修改了 crate 对外接口/文件结构时，已同步更新对应 `AGENTS.md`
- [x] 已阅读 [贡献指南](../CONTRIBUTING.md)
- [ ] 首次贡献已签署 [CLA](../CLA.md)（待 PR 创建后的 CLA Assistant 流程）
