### PR TITLE
feat(deploy): Register-Tsf 改为系统目录副本注册模式（待文档佐证）

### DIFF
--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -837,16 +837,27 @@ function Unregister-Tsf ([string]$dir, [string]$suffix) {
 }
 
 # 注册 TSF COM (x64 必须成功; x86 失败仅告警, 不阻断 64 位使用)。
+# 模式: 先复制 DLL 到系统目录, 对系统副本 regsvr32 (对齐 weasel 安装模式与 wind-installer):
+# Win11 输入栈的 GIP 路径 (游戏聊天框等上下文) 只激活位于系统目录的 in-proc TSF IME DLL,
+# 安装目录副本会被 msctf 在 COM 激活前静默筛除。注册系统副本时 DllRegisterServer 内
+# GetModuleFileName 取到的即系统目录路径, InprocServer32 自然指向系统副本, 无需后处理。
 function Register-Tsf ([string]$dir, [string]$suffix) {
-    $x64 = Join-Path $dir "wind_tsf$suffix.dll"
-    $x86 = Join-Path $dir "wind_tsf_x86${suffix}.dll"
-    & regsvr32 /s $x64
-    if ($LASTEXITCODE -ne 0) { ErrMsg "  - x64 COM 注册失败: $x64"; return $false }
-    Gray "  - x64 COM 已注册"
-    if (Test-Path $x86) {
-        & (Get-Regsvr32X86) /s $x86
+    $sid = "*S-1-15-2-1"  # ALL APPLICATION PACKAGES (AppContainer 宿主读取需要)
+    $x64Src = Join-Path $dir "wind_tsf$suffix.dll"
+    $x64Dst = Join-Path $env:WINDIR "System32\wind_tsf$suffix.dll"
+    Copy-Item $x64Src $x64Dst -Force
+    & icacls $x64Dst /grant "${sid}:(RX)" /c | Out-Null
+    & regsvr32 /s $x64Dst
+    if ($LASTEXITCODE -ne 0) { ErrMsg "  - x64 COM 注册失败: $x64Dst"; return $false }
+    Gray "  - x64 COM 已注册 (系统目录: $x64Dst)"
+    $x86Src = Join-Path $dir "wind_tsf_x86${suffix}.dll"
+    if (Test-Path $x86Src) {
+        $x86Dst = Join-Path $env:WINDIR "SysWOW64\wind_tsf_x86${suffix}.dll"
+        Copy-Item $x86Src $x86Dst -Force
+        & icacls $x86Dst /grant "${sid}:(RX)" /c | Out-Null
+        & (Get-Regsvr32X86) /s $x86Dst
         if ($LASTEXITCODE -ne 0) { Warn "  - x86 COM 注册失败 (32 位应用可能无法使用输入法)" }
-        else { Gray "  - x86 COM 已注册" }
+        else { Gray "  - x86 COM 已注册 (系统目录: $x86Dst)" }
     }
     return $true
 }


### PR DESCRIPTION
## 说明（按作者建议拆分）

原 PR 同时包含 Register.cpp 修正与 dev.ps1 系统目录注册。现已拆分：

- ThreadingModel / 类别 GUID 修正 → #116（可先合）
- 本 PR 仅保留 `dev.ps1` 的 `Register-Tsf` 系统目录注册模式，配套 wind-installer 侧实现（huanfeng/wind-installer#1）

## 改动

`Register-Tsf` 改为「复制 DLL 到系统目录（x64 → System32，x86 → SysWOW64）→ 授 AppContainer 读权限 → 对系统副本 regsvr32」——`DllRegisterServer` 内 `GetModuleFileName` 取到系统目录路径，`InprocServer32` 自然指向系统副本。

## 依据（待文档佐证，完整讨论见 #115）

- 官方文档无「必须 System32」明文；最接近条款为 [IME requirements](https://learn.microsoft.com/en-us/windows/apps/develop/input/input-method-editor-requirements) 的 AppContainer 可读性（IME 文件须位于 Program Files 或 Windows 目录，IME DLL 受同样限制）
- 真机 A/B 实验（唯一变量为 `InprocServer32` 指向）：Program Files 注册 → GIP 上下文（游戏聊天框）选不上；System32 副本注册 → 正常（完整记录见 #115）
- 全行业实践：inbox IME、weasel、Corvus SKK 均部署在系统目录树（本机注册表实测）

## 验证

- `dev.ps1 dm1` 构建通过；等效手工部署（DLL 入 system32 + Apartment）实测流放之路国际服（含管理员权限）与英雄联盟游戏内输入恢复正常（#115）
